### PR TITLE
ref.listenについてのサンプルクラスを追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_practice/riverpod/future_provider/future_provider_page.dart';
+import 'package:riverpod_practice/riverpod/listen_provider/listen_provider_page.dart';
 import 'package:riverpod_practice/riverpod/provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_notifier_provider/state_notifier_provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_provider_page.dart';
@@ -19,7 +20,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const FutureProviderPage(),
+      home: const ListenProviderPage(),
     );
   }
 }

--- a/lib/riverpod/listen_provider/listen_provider_page.dart
+++ b/lib/riverpod/listen_provider/listen_provider_page.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// Provider example.
+final counterProvider = StateProvider((ref) => 0);
+
+// Widget example.
+class ListenProviderPage extends ConsumerWidget {
+  const ListenProviderPage({super.key});
+
+  static String title = 'Listen Provider';
+  static String routeName = 'listen-provider';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Providerを購読する
+    ref.listen<int>(
+      counterProvider,
+          (previous, next) {
+        // Counterの数値が奇数になったときにだけダイアログを表示する
+        if (next.isOdd) {
+          return;
+        }
+        showDialog<void>(
+          context: context,
+          builder: (context) {
+            return const AlertDialog(
+              title: Text('Current number is Odd !!'),
+            );
+          },
+        );
+      },
+      // エラーハンドリング（省略可能）
+      onError: (error, stackTrace) => debugPrint('$error'),
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                // counterProviderの状態（カウント数）をTextで表示
+                Text(
+                  'Count: ${ref.watch(counterProvider)}',
+                  style: Theme.of(context).textTheme.headline2,
+                ),
+                ElevatedButton(
+                  // ボタンタップでcounterProviderの状態をプラス１する
+                  // ↓ `counter.state++` や、
+                  // ↓ `counter.state = counter.state + 1` と書いても同じ。
+                  onPressed: () => ref
+                      .read(counterProvider.notifier)
+                      .update((state) => state + 1),
+                  child: const Text('Increment'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
#5 ref.listenの使い方
ref.listenで、Providerの監視とそのハンドリング可能になる。
→ Providerの状態が変更されたとき、その変更を検知して画面遷移やダイアログを表示させることが可能になる。
ref.listen<T>(第1引数, 第2引数, (第3引数));
第1引数にプロバイダ
第2引数に状態が変化した際に実行する関数
第3引数にonErrorでエラーハンドリングが可能(省略可能)