### PR TITLE
Feature/refresh provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_practice/riverpod/future_provider/future_provider_page.dart';
 import 'package:riverpod_practice/riverpod/listen_provider/listen_provider_page.dart';
 import 'package:riverpod_practice/riverpod/provider_page.dart';
+import 'package:riverpod_practice/riverpod/refresh_provider/refresh_provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_notifier_provider/state_notifier_provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_provider_page.dart';
 
@@ -20,7 +21,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const ListenProviderPage(),
+      home: const RefreshProviderPage(),
     );
   }
 }

--- a/lib/riverpod/refresh_provider/refresh_provider_page.dart
+++ b/lib/riverpod/refresh_provider/refresh_provider_page.dart
@@ -34,6 +34,7 @@ class RefreshProviderPage extends ConsumerWidget {
           )
         ],
       ),
+      // <AsyncValue>provider.whenでデータの取得処理
       body: user.when(
         // 非同期処理実行中はインジケーターを表示
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -43,10 +44,12 @@ class RefreshProviderPage extends ConsumerWidget {
             padding: const EdgeInsets.all(5.0),
             child: Column(
               children: [
+                // リフレッシュ処理
                 ElevatedButton(
                     onPressed: () async => ref.refresh(_githubUserProvider),
                     child: const Icon(Icons.refresh),
                 ),
+                // エラー内容
                 Expanded(
                     child: SingleChildScrollView(child: Text('Error: $error, $stack'))),
 
@@ -65,6 +68,7 @@ class RefreshProviderPage extends ConsumerWidget {
               children: [
                 ListTile(
                   title: const Text('login'),
+                  // nullの可能性があるので、強制アンラップ(user!)をする必要がある
                   subtitle: Text('${user!['login'] ?? 'none'}'),
                 ),
                 ListTile(

--- a/lib/riverpod/refresh_provider/refresh_provider_page.dart
+++ b/lib/riverpod/refresh_provider/refresh_provider_page.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+final _githubUserProvider = FutureProvider<Map<String, Object?>>((ref) async {
+  const String username = 'trm11tkr';
+  final response = await http.get(Uri.https(
+    'api.github.com',
+    'users/$username',
+  ));
+  return json.decode(response.body);
+});
+
+class RefreshProviderPage extends ConsumerWidget {
+  const RefreshProviderPage({Key? key}) : super(key: key);
+
+  static const String title = 'refreshProvider';
+  static const String routeName = 'refresh-provider';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Map<String, Object?>? 型となるので、 利用時にnullチェックが必要
+    final AsyncValue<Map<String, Object?>?> user =
+        ref.watch(_githubUserProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(title),
+        actions: [
+          IconButton(
+              onPressed: () async => ref.refresh(_githubUserProvider),
+              icon: const Icon(Icons.refresh,),
+          )
+        ],
+      ),
+      body: user.when(
+        // 非同期処理実行中はインジケーターを表示
+        loading: () => const Center(child: CircularProgressIndicator()),
+        // エラーが発生した場合はエラー情報を表示
+        error: (error, stack) {
+          return Container(
+            padding: const EdgeInsets.all(5.0),
+            child: Column(
+              children: [
+                ElevatedButton(
+                    onPressed: () async => ref.refresh(_githubUserProvider),
+                    child: const Icon(Icons.refresh),
+                ),
+                Expanded(
+                    child: SingleChildScrollView(child: Text('Error: $error, $stack'))),
+
+              ],
+            ),
+          );
+        },
+        // 非同期処理が完了したら `data` プロパティの引数として受け取れる。
+        data: (user) {
+          return RefreshIndicator(
+            // RefreshIndicatorでListView等を囲み、 `onRefresh` で動作を指定すれば引っ張って更新できるようになる
+            // `ref.refresh()` でProviderを更新
+            onRefresh: () async => ref.refresh(_githubUserProvider),
+            child: ListView(
+              padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+              children: [
+                ListTile(
+                  title: const Text('login'),
+                  subtitle: Text('${user!['login'] ?? 'none'}'),
+                ),
+                ListTile(
+                  title: const Text('id'),
+                  subtitle: Text('${user['id'] ?? 'none'}'),
+                ),
+                ListTile(
+                  title: const Text('html_url'),
+                  subtitle: Text('${user['html_url'] ?? 'none'}'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,6 +256,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   hooks_riverpod: ^1.0.4
   freezed_annotation: ^2.0.3
   json_annotation: ^4.5.0
+  http: ^0.13.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- GitHubのユーザ情報を取得
- ref.refreshについての学習なのでデータクラスは作成していない

# ref.refresh #8 
FutureProviderではStreamと違い、1度取得が終わったら通常更新はされない
`ref.refresh(_githubUserProvider)`で強制的にProviderを更新することが可能
```dart
final _githubUserProvider = FutureProvider<Map<String, Object?>>((ref) async {
  const String username 'test';
  final response = await http.get(Uri.https(
    'api.github.com',
    'users/$username',
  ));
  return json.decode(response.body);
});

// 省略
Widget build(BuildContext context, WidgetRef ref) {
    // Map<String, Object?>? 型となるので、 利用時にnullチェックが必要
    final AsyncValue<Map<String, Object?>?> user = ref.watch(_githubUserProvider);
    return Scaffold(
      body: user.when(
        loading: () {}, // loadingハンドリングが用意されている
        error: (error, stack) {}, // errorハンドリングが用意されている
        data: (user) {
          // ここにデータ取得後の処理を記述
          return RefreshIndicator(
            onRefresh: () => ref.refresh(_githubUserProvider),
            // Provider更新
            child: ListView(), //  データの表示処理(省略)
          );
        },
      ),
    );
```

