### PR TITLE
ref.readとref.watchの比較

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_practice/riverpod/future_provider/future_provider_page.
 import 'package:riverpod_practice/riverpod/listen_provider/listen_provider_page.dart';
 import 'package:riverpod_practice/riverpod/provider_page.dart';
 import 'package:riverpod_practice/riverpod/refresh_provider/refresh_provider_page.dart';
+import 'package:riverpod_practice/riverpod/read_provider/read_provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_notifier_provider/state_notifier_provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_provider_page.dart';
 
@@ -21,7 +22,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const RefreshProviderPage(),
+      home: const ReadProviderPage(),
     );
   }
 }

--- a/lib/riverpod/read_provider/read_provider_page.dart
+++ b/lib/riverpod/read_provider/read_provider_page.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final StateProvider counterProvider = StateProvider<int>((ref) => 0);
+class ReadProviderPage extends ConsumerWidget {
+  const ReadProviderPage({Key? key}) : super(key: key);
+  static String title = 'Read Provider';
+  static String routeName = 'read-provider';
+
+  /// watch: 更新されたProviderデータ取得 & ビューに反映(更新)
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final counter = ref.watch(counterProvider);
+    return ElevatedButton(
+      onPressed: () => ref.watch(counterProvider.notifier).state++,
+      child: Text('変化あり: $counter')
+    );
+
+  // /// watch: 更新されたProviderデータ取得 & ビューに反映(更新)
+  // @override
+  // Widget build(BuildContext context, WidgetRef ref) {
+  //   return ElevatedButton(
+  //     onPressed: () => ref.read(counterProvider.notifier).state++,
+  //     child: Text('変化なし: ${ref.read(counterProvider)}')
+  //   );
+  }
+}


### PR DESCRIPTION
Closes #7 
ref.watch : イベントによって更新Providerデータの取得 & ビューへ反映(rebuild)
　　　　　ホットリロード時に引き継ぎ

ref.read : イベントによって更新Providerデータの取得(rebuildしない・ホットリロードすると反映)

