### PR TITLE
ProviderScopeの活用方法

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_practice/riverpod/future_provider/future_provider_page.dart';
 import 'package:riverpod_practice/riverpod/listen_provider/listen_provider_page.dart';
 import 'package:riverpod_practice/riverpod/provider_page.dart';
+import 'package:riverpod_practice/riverpod/provider_scope/with_provider_scope.dart';
+import 'package:riverpod_practice/riverpod/provider_scope/without_provider_scope.dart';
 import 'package:riverpod_practice/riverpod/refresh_provider/refresh_provider_page.dart';
 import 'package:riverpod_practice/riverpod/read_provider/read_provider_page.dart';
 import 'package:riverpod_practice/riverpod/state_notifier_provider/state_notifier_provider_page.dart';
@@ -22,7 +24,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const ReadProviderPage(),
+      home: const WithProviderScopePage(),
     );
   }
 }

--- a/lib/riverpod/provider_scope/with_provider_scope.dart
+++ b/lib/riverpod/provider_scope/with_provider_scope.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// indexを読み取る予定なので初期値は持たない
+// → エラーを投げる(後からoverridesで上書きされるため心配なし)
+final currentIndex = Provider<int>((_) => throw UnimplementedError());
+
+// nullを許容する記述方法もある
+// final currentIndex = Provider<int?>((_) => null);
+
+class WithProviderScopePage extends StatelessWidget {
+  const WithProviderScopePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView.builder(
+          itemBuilder: (context, index) {
+            return ProviderScope(
+              // overridesで上書きが可能(本来ベーシックなProviderは外部から変更できない)
+              overrides: [
+                currentIndex.overrideWithValue(index),
+              ],
+              // constでインスタンス化できる
+              child: const ConstItemTile(),
+            );
+          }
+      ),
+    );
+  }
+}
+
+class ConstItemTile extends ConsumerWidget {
+  const ConstItemTile({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final index = ref.watch(currentIndex);
+    return ListTile(title: Text('$index番目のitem'));
+  }
+}

--- a/lib/riverpod/provider_scope/without_provider_scope.dart
+++ b/lib/riverpod/provider_scope/without_provider_scope.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class WithoutProviderScopePage extends StatelessWidget {
+  const WithoutProviderScopePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView.builder(
+        itemBuilder: (BuildContext context, int index) {
+          // const修飾子がないので、ListViewがリビルドされると全てのItemTileもリビルドされる
+          return ItemTile(index: index);
+        },
+      ),
+    );
+  }
+}
+
+class ItemTile extends StatelessWidget {
+  const ItemTile({Key? key, required this.index}) : super(key: key);
+
+// TodoListPageのListViewから受け取る index
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(title: Text('$index番目のitem'));
+  }
+}


### PR DESCRIPTION
### ProviderScopeを使い、特定の範囲内でProviderの上書きをする。
ベーシックな`Provider`は外部から変更できないため、
初期値をアプリ起動後や非同期に設定したい場合に困る。
そこで独自にProviderScopeを設定することで上書きが可能となる。
```dart
// indexを読み取る予定なので初期値は持たない
// → エラーを投げる(後からoverridesで上書きされるため心配なし)
final currentIndex = Provider<int>((_) => throw UnimplementedError());
class WithProviderScopePage extends StatelessWidget {
  const WithProviderScopePage({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: ListView.builder(
          itemBuilder: (context, index) {
            return ProviderScope(
              // overridesで上書きが可能(本来ベーシックなProviderは外部から変更できない)
              overrides: [
                currentIndex.overrideWithValue(index),
              ],
              // constでインスタンス化できる
              child: const ConstItemTile(),
            );
          }
      ),
    );
  }
}
```